### PR TITLE
Use checksum to verify cookbook integrity

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This is the place you can extend the funcitonality of the studio
+
+hab pkg install chef/studio-common >/dev/null
+source "$(hab pkg path chef/studio-common)/bin/studio-common"
+
+function run_tests() {
+  install_if_missing core/go go
+  install_if_missing core/gcc gcc
+  go test
+}

--- a/cookbook_download.go
+++ b/cookbook_download.go
@@ -5,6 +5,9 @@
 package chef
 
 import (
+	"crypto/md5"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -73,8 +76,7 @@ func (c *CookbookService) downloadCookbookItems(items []CookbookItem, itemType, 
 	}
 
 	for _, item := range items {
-		itemPath := path.Join(localPath, item.Name)
-		if err := c.downloadCookbookFile(item.Url, itemPath); err != nil {
+		if err := c.downloadCookbookFile(item, localPath); err != nil {
 			return err
 		}
 	}
@@ -83,11 +85,14 @@ func (c *CookbookService) downloadCookbookItems(items []CookbookItem, itemType, 
 }
 
 // downloadCookbookFile downloads a single cookbook file to disk
-func (c *CookbookService) downloadCookbookFile(url, file string) error {
-	request, err := c.client.NewRequest("GET", url, nil)
+func (c *CookbookService) downloadCookbookFile(item CookbookItem, localPath string) error {
+	filePath := path.Join(localPath, item.Name)
+
+	request, err := c.client.NewRequest("GET", item.Url, nil)
 	if err != nil {
 		return err
 	}
+
 	response, err := c.client.Do(request, nil)
 	if response != nil {
 		defer response.Body.Close()
@@ -96,13 +101,38 @@ func (c *CookbookService) downloadCookbookFile(url, file string) error {
 		return err
 	}
 
-	f, err := os.Create(file)
+	f, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	if _, err := io.Copy(f, response.Body); err != nil {
 		return err
 	}
-	return nil
+
+	if verifyMD5Checksum(filePath, item.Checksum) {
+		return nil
+	}
+
+	return errors.New("wrong checksum")
+}
+
+func verifyMD5Checksum(filePath, checksum string) bool {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return false
+	}
+
+	md5String := fmt.Sprintf("%x", hash.Sum(nil))
+	if md5String == checksum {
+		return true
+	}
+	return false
 }

--- a/cookbook_download.go
+++ b/cookbook_download.go
@@ -6,7 +6,6 @@ package chef
 
 import (
 	"crypto/md5"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -115,7 +114,11 @@ func (c *CookbookService) downloadCookbookFile(item CookbookItem, localPath stri
 		return nil
 	}
 
-	return errors.New("wrong checksum")
+	return fmt.Errorf(
+		"cookbook file '%s' checksum mismatch. (expected:%s)",
+		filePath,
+		item.Checksum,
+	)
 }
 
 func verifyMD5Checksum(filePath, checksum string) bool {

--- a/cookbook_download_test.go
+++ b/cookbook_download_test.go
@@ -93,7 +93,7 @@ func TestCookbooksDownloadTo(t *testing.T) {
     {
       "name": "default.rb",
       "path": "recipes/default.rb",
-      "checksum": "320sdk2w38020827kdlsdkasbd5454b6",
+      "checksum": "8e751ed8663cb9b97499956b6a20b0de",
       "specificity": "default",
       "url": "` + server.URL + `/bookshelf/foo/default_rb"
     }
@@ -103,7 +103,7 @@ func TestCookbooksDownloadTo(t *testing.T) {
     {
       "name": "metadata.rb",
       "path": "metadata.rb",
-      "checksum": "14963c5b685f3a15ea90ae51bd5454b6",
+      "checksum": "6607f3131919e82dc4ba4c026fcfee9f",
       "specificity": "default",
       "url": "` + server.URL + `/bookshelf/foo/metadata_rb"
     }
@@ -151,4 +151,22 @@ func TestCookbooksDownloadTo(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "log 'this is a resource'", string(recipeBytes))
 	}
+}
+
+func TestVerifyMD5Checksum(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "md5-test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tempDir) // clean up
+
+	var (
+		// if someone changes the test data,
+		// you have to also update the below md5 sum
+		testData = []byte("hello\nchef\n")
+		filePath = path.Join(tempDir, "dat")
+	)
+	err = ioutil.WriteFile(filePath, testData, 0644)
+	assert.Nil(t, err)
+	assert.True(t, verifyMD5Checksum(filePath, "70bda176ac4db06f1f66f96ae0693be1"))
 }


### PR DESCRIPTION
Closes https://github.com/chef/go-chef/issues/3

To run the tests you can enter a habitat studio and run `run_tests`:
```
➜  go-chef git:(afiune/3/cookbook-download/verify-checksum) hab studio enter
[1][default:/src:0]# run_tests
apache2 => http://localhost:4000/cookbooks/apache2
 * 5.1.0
 * 4.2.0
nginx => http://localhost:4000/cookbooks/nginx
 * 1.0.0
 * 0.3.0

apache2 => http://localhost:4000/cookbooks/apache2
 * 5.1.0
 * 4.2.0

[apache2 apache2::mod_access_compat apache2::mod_actions apache2::mod_alias]
.
1 total assertion
.
2 total assertions
.
3 total assertions
.
4 total assertions
.
5 total assertions
.
6 total assertions
...
9 total assertions
.
10 total assertions
.
11 total assertions

PASS
ok  	github.com/chef/go-chef	0.300s
[2][default:/src:0]#
```

Signed-off-by: Salim Afiune <afiune@chef.io>