### PR TITLE
Revert "Point to the right repository"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-chef/chef
+module github.com/chef/go-chef
 
 go 1.12
 


### PR DESCRIPTION
It seems that pull all forked repo changes here.

Need to Revert "Point to the right repository" causes:

while running `go get -u github.com/chef/go-chef@master`
```
go: finding github.com/chef/go-chef master
go get: github.com/chef/go-chef@v0.4.1-0.20200323203039-ba4b81eda9f0: parsing go.mod:
	module declares its path as: github.com/go-chef/chef
	        but was required as: github.com/chef/go-chef

```

    
This reverts commit c5e7eec52bee3ccfc8ed61875a165fe819cbe774.

